### PR TITLE
バッチ用S3バケットポリシーを修正

### DIFF
--- a/eks-env/40_s3_batch_cfn.yaml
+++ b/eks-env/40_s3_batch_cfn.yaml
@@ -45,6 +45,7 @@ Resources:
             Action:
               - s3:GetObject
               - s3:DeleteObject
+              - s3:PutObject
             Effect: Allow
             Principal:
               AWS: !GetAtt BatchUser.Arn


### PR DESCRIPTION
はじめまして、著書を購入して読ませていただいています！
一部手順通りに動かない箇所があったので、PRを送らせていただきます。
個人の環境に依存していた可能性もあるのですが、ご確認いただけると幸いです :pray:

## 起きた事象
`2-6-9 バッチアプリケーションのデプロイ` において、バッチアプリケーションが失敗し、 `CrashLoopBackOff` を繰り返していた。


<details><summary> Spring のエラーログ（一部抜粋） </summary>

```log
Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied;
Request ID: 3D315BFD77A1AFFE; S3 Extended Request ID: hwr/N01N0R/zSk0aLu4v4zh1ZQ6OfAr2o+0b5npz1dA01XtQfquNJUS5+KmshRHekRSm3+Qwsxw=)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1660)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1324)
        at  com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1074)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:745)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:719)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:701)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:669)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:651)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:515)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4443)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4390)
        at com.amazonaws.services.s3.AmazonS3Client.copyObject(AmazonS3Client.java:1907)
        at com.amazonaws.services.s3.AmazonS3Client.copyObject(AmazonS3Client.java:1862)
        at k8sbook.sampleapp.aws.S3FileHandler.copyFile(S3FileHandler.java:41)
        at k8sbook.sampleapp.aws.S3FileHandler.moveFileToWorkFolder(S3FileHandler.java:46)
        at k8sbook.sampleapp.LocationDataLoader.findTargetFiles(LocationDataLoader.java:98)
```
</details>

## 原因と思われる箇所
バッチの `S3FileHandler#copyFile` の実行の際、バッチ用S3バケットに対する書き込み権限がないため失敗している。

### Batch側
https://github.com/kazusato/k8sbook/blob/master/batch-app/src/main/java/k8sbook/sampleapp/aws/S3FileHandler.java#L40-L42

### CFn側
https://github.com/kazusato/k8sbook/blob/master/eks-env/40_s3_batch_cfn.yaml#L45-L47

## 修正案
CFn で作成するバッチ用S3バケットの Policy に `s3:PutObject` を追加。
