### PR TITLE
update 10.6 -> 10.21 in EksWorkDB

### DIFF
--- a/eks-env/10_rds_ope_cfn.yaml
+++ b/eks-env/10_rds_ope_cfn.yaml
@@ -125,7 +125,7 @@ Resources:
     Properties:
       DBInstanceIdentifier: eks-work-db
       Engine: postgres
-      EngineVersion: 10.6
+      EngineVersion: 10.21
       DBInstanceClass: db.t2.micro
       AllocatedStorage: 30
       StorageType: gp2
@@ -185,7 +185,7 @@ Resources:
     Type: AWS::RDS::DBParameterGroup
     Properties:
       Family: postgres10
-      Description: Parameter Group for PostgreSQL 10.6
+      Description: Parameter Group for PostgreSQL 10.21
 
   OpeServerSubnet:
     Type: AWS::EC2::Subnet


### PR DESCRIPTION
When the default 10_rds_ope_cfn.yaml was applied to the CloudFormation service, the error occurs, "Resource handler returned message: "Cannot find version 10.6 for postgres (Service: Rds, Status Code: 400, Request ID: xxxxxx" in EksWorkDB.

I checked the support version in postgresDB with the below command.

```sh
$ aws rds describe-db-engine-versions --engine postgres
{
    "DBEngineVersions": [
        {
            "Engine": "postgres",
            "EngineVersion": "10.17",
            "DBParameterGroupFamily": "postgres10",
            "DBEngineDescription": "PostgreSQL",
            "DBEngineVersionDescription": "PostgreSQL 10.17-R1",
            "ValidUpgradeTarget": [
                {
                    "Engine": "postgres",
                    "EngineVersion": "10.18",
                    "Description": "PostgreSQL 10.18-R1",
                    "AutoUpgrade": true,
                    "IsMajorVersionUpgrade": false
                },
                {
                    "Engine": "postgres",
                    "EngineVersion": "10.19",
                    "Description": "PostgreSQL 10.19-R1",
                    "AutoUpgrade": false,
                    "IsMajorVersionUpgrade": false
                },
                {
                    "Engine": "postgres",
                    "EngineVersion": "10.20",
                    "Description": "PostgreSQL 10.20-R1",
                    "AutoUpgrade": false,
                    "IsMajorVersionUpgrade": false
                },
                {
                    "Engine": "postgres",
                    "EngineVersion": "10.21",
                    "Description": "PostgreSQL 10.21-R1",
                    "AutoUpgrade": false,
                    "IsMajorVersionUpgrade": false
                },
```

When I update postgres version from 10.6 to 10.21, it works! Please check the configuration with your environments.

Thanks!